### PR TITLE
update the dev server command in setup documentation as per package definiton (npm run develop -> npm run dev)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 Prerequirements: NodeJS 7+, NPM 4+. Install needed deps via ``npm install``.
 
-To run development server you need to run ``npm run develop`` and open [http://localhost:8106](http://localhost:8106).
+To run development server you need to run ``npm run dev`` and open [http://localhost:8106](http://localhost:8106).
 
 To compile the app (without dev server stuff) run ``npm run bundle``.


### PR DESCRIPTION
https://github.com/circlecell/jsonlint.com/blob/0c6fb1e2b222f089a886d5c85dfadd384ec9ce88/package.json#L9
is not compatible with the documentation because of which it raises missing script error.